### PR TITLE
support ntlm proxy auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fatedier/golib
 go 1.12
 
 require (
+	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c
 	github.com/golang/snappy v0.0.1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
+github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/net/proxy.go
+++ b/net/proxy.go
@@ -18,11 +18,12 @@ import (
 	"bufio"
 	"encoding/base64"
 	"fmt"
+	"github.com/Azure/go-ntlmssp"
+	"golang.org/x/net/proxy"
 	"net"
 	"net/http"
 	"net/url"
-
-	"golang.org/x/net/proxy"
+	"strings"
 )
 
 type ProxyAuth struct {
@@ -51,6 +52,8 @@ func DialTcpByProxy(proxyStr string, addr string) (c net.Conn, err error) {
 	switch proxyUrl.Scheme {
 	case "http":
 		return DialTcpByHttpProxy(proxyUrl.Host, addr, auth)
+	case "ntlm":
+		return DialTcpByNTLMHttpProxy(proxyUrl.Host, addr, auth)
 	case "socks5":
 		return DialTcpBySocks5Proxy(proxyUrl.Host, addr, auth)
 	default:
@@ -58,7 +61,62 @@ func DialTcpByProxy(proxyStr string, addr string) (c net.Conn, err error) {
 		return
 	}
 }
+func DialTcpByNTLMHttpProxy(proxyHost string, dstAddr string, auth *ProxyAuth) (c net.Conn, err error) {
+	if c, err = net.Dial("tcp", proxyHost); err != nil {
+		return
+	}
 
+	req, err := http.NewRequest("CONNECT", "http://"+dstAddr, nil)
+	if err != nil {
+		return
+	}
+	if auth.Enable {
+		domain := ""
+		_, domain = ntlmssp.GetDomain(auth.Username)
+		negotiateMessage, err := ntlmssp.NewNegotiateMessage(domain, "")
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Add("Proxy-Authorization", "Negotiate "+base64.StdEncoding.EncodeToString(negotiateMessage))
+	}
+	req.Write(c)
+	resp, err := http.ReadResponse(bufio.NewReader(c), req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	if auth.Enable && resp.StatusCode == 407 {
+		challenge := resp.Header.Get("Proxy-Authenticate")
+		username, _ := ntlmssp.GetDomain(auth.Username)
+		if strings.HasPrefix(challenge, "Negotiate ") {
+			challengeMessage, err := base64.StdEncoding.DecodeString(challenge[len("Negotiate "):])
+			if err != nil {
+				return nil, err
+			}
+			authenticateMessage, err := ntlmssp.ProcessChallenge(challengeMessage, username, auth.Passwd)
+			if err != nil {
+				return nil, err
+			}
+			req, err := http.NewRequest("CONNECT", "http://"+dstAddr, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Add("Proxy-Authorization", "Negotiate "+base64.StdEncoding.EncodeToString(authenticateMessage))
+			req.Write(c)
+			resp, err = http.ReadResponse(bufio.NewReader(c), req)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body.Close()
+		}
+	}
+	if resp.StatusCode != 200 {
+		err = fmt.Errorf("DialTcpByNTLMHttpProxy error, StatusCode [%d]", resp.StatusCode)
+		return
+	}
+	return
+}
 func DialTcpByHttpProxy(proxyHost string, dstAddr string, auth *ProxyAuth) (c net.Conn, err error) {
 	if c, err = net.Dial("tcp", proxyHost); err != nil {
 		return


### PR DESCRIPTION
frpc配置项`http_proxy`可使用`ntlm://`来指定ntlm认证的代理

```ini
[common]
server_addr = x.x.x.x
server_port = 443
# %5c为url编码,用于分割domain和username
# 如果没有domain,则格式是ntlm://username:pass@192.168.213.187:8080
# 如果pass中有特殊符号则要进行url编码
http_proxy = ntlm://domain%5cusername:pass@192.168.213.187:8080
token = xxxx

[socks5] 
type = tcp
remote_port = 9066 
plugin = socks5 
```

测试使用`Microsoft ISA Server`无问题

![image](https://user-images.githubusercontent.com/10806806/91048735-a9dea600-e64e-11ea-8436-9d192236a908.png)


相关issue:

https://github.com/fatedier/frp/issues/1924

https://github.com/fatedier/frp/issues/1952