### PR TITLE
feat: support aead crypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# editors
+.vscode
+.idea
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/crypto/aead_reader.go
+++ b/crypto/aead_reader.go
@@ -1,0 +1,76 @@
+package crypto
+
+import (
+	"crypto/cipher"
+	"encoding/binary"
+	"github.com/fatedier/golib/pool"
+	"io"
+	"sync"
+)
+
+type AeadReader struct {
+	S     cipher.AEAD
+	R     io.Reader
+	nonce []byte
+	buf   []byte
+	start int
+	mu    sync.Mutex
+}
+
+func NewAeadReader(S cipher.AEAD, R io.Reader) *AeadReader {
+	return &AeadReader{
+		S:     S,
+		R:     R,
+		nonce: make([]byte, S.NonceSize()),
+	}
+}
+
+// Read reads an AEAD chunk at a time
+func (r *AeadReader) Read(dst []byte) (n int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.buf != nil {
+		n = copy(dst, r.buf[r.start:])
+		r.start += n
+		if r.start >= len(r.buf) {
+			pool.PutBuf(r.buf)
+			r.buf = nil
+		}
+		return n, nil
+	}
+	bLength := pool.GetBuf(2 + r.S.Overhead())
+	defer pool.PutBuf(bLength)
+	if _, err = io.ReadFull(r.R, bLength); err != nil {
+		return 0, err
+	}
+	// decrypt the length of the chunk
+	if bLength, err = r.S.Open(bLength[:0], r.nonce, bLength, nil); err != nil {
+		return 0, err
+	}
+	BytesIncLittleEndian(r.nonce)
+
+	u16Length := binary.BigEndian.Uint16(bLength)
+	buf := pool.GetBuf(int(u16Length) + r.S.Overhead())
+	defer func() {
+		if err != nil {
+			pool.PutBuf(buf)
+		}
+	}()
+	if _, err = io.ReadFull(r.R, buf); err != nil {
+		return 0, err
+	}
+	// decrypt the encrypted text
+	if buf, err = r.S.Open(buf[:0], r.nonce, buf, nil); err != nil {
+		return 0, err
+	}
+	BytesIncLittleEndian(r.nonce)
+	// store the unread bytes
+	n = copy(dst, buf)
+	if n < len(buf) {
+		r.buf = buf
+		r.start = n
+	} else {
+		pool.PutBuf(buf)
+	}
+	return n, nil
+}

--- a/crypto/aead_writer.go
+++ b/crypto/aead_writer.go
@@ -1,0 +1,83 @@
+package crypto
+
+import (
+	"crypto/cipher"
+	"encoding/binary"
+	"github.com/fatedier/golib/pool"
+	"io"
+	"sync"
+)
+
+const (
+	AeadMaxChunkLength = (1 << 14) - 1
+)
+
+type AeadWriter struct {
+	S     cipher.AEAD
+	W     io.Writer
+	nonce []byte
+	mu    sync.Mutex
+}
+
+func NewAeadWriter(S cipher.AEAD, W io.Writer) *AeadWriter {
+	return &AeadWriter{
+		S:     S,
+		W:     W,
+		nonce: make([]byte, S.NonceSize()),
+	}
+}
+
+func (w *AeadWriter) Write(src []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.write(src)
+}
+
+func (w *AeadWriter) write(src []byte) (n int, err error) {
+	var nBase int
+	if len(src) > AeadMaxChunkLength {
+		handleLength := len(src) % AeadMaxChunkLength
+		if handleLength == 0 {
+			handleLength = AeadMaxChunkLength
+		}
+		if nBase, err = w.write(src[:len(src)-handleLength]); err != nil {
+			return nBase, err
+		}
+		src = src[len(src)-handleLength:]
+	}
+	c := pool.GetBuf(2 + w.S.Overhead() + len(src) + w.S.Overhead())
+	defer pool.PutBuf(c)
+	// put the length into the first two bytes, then the overhead
+	binary.BigEndian.PutUint16(c[:2], uint16(len(src)))
+	w.S.Seal(c[:0], w.nonce, c[:2], nil)
+	BytesIncLittleEndian(w.nonce)
+
+	// encrypt the plaintext
+	w.S.Seal(c[2+w.S.Overhead():2+w.S.Overhead()], w.nonce, src, nil)
+	BytesIncLittleEndian(w.nonce)
+
+	// write the encrypted text
+	nWrite, err := w.W.Write(c)
+	if nWrite != len(c) && err == nil { // should never happen
+		err = io.ErrShortWrite
+	}
+	return nBase + len(src), nil
+}
+
+// Close closes the underlying Writer and returns its Close return value, if the Writer
+// is also an io.Closer. Otherwise it returns nil.
+func (w *AeadWriter) Close() error {
+	if c, ok := w.W.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+func BytesIncLittleEndian(b []byte) {
+	for i := 0; i < len(b); i++ {
+		b[i]++
+		if b[i] != 0 {
+			break
+		}
+	}
+}

--- a/crypto/aead_writer.go
+++ b/crypto/aead_writer.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	AeadMaxChunkLength = (1 << 14) - 1
+	AeadMaxTextLength = (1 << 14) - 1
 )
 
 type AeadWriter struct {
@@ -35,10 +35,10 @@ func (w *AeadWriter) Write(src []byte) (n int, err error) {
 
 func (w *AeadWriter) write(src []byte) (n int, err error) {
 	var nBase int
-	if len(src) > AeadMaxChunkLength {
-		handleLength := len(src) % AeadMaxChunkLength
+	if len(src) > AeadMaxTextLength {
+		handleLength := len(src) % AeadMaxTextLength
 		if handleLength == 0 {
-			handleLength = AeadMaxChunkLength
+			handleLength = AeadMaxTextLength
 		}
 		if nBase, err = w.write(src[:len(src)-handleLength]); err != nil {
 			return nBase, err

--- a/io/io.go
+++ b/io/io.go
@@ -42,12 +42,12 @@ func Join(c1 io.ReadWriteCloser, c2 io.ReadWriteCloser) (inCount int64, outCount
 	return
 }
 
-func WithEncryption(rwc io.ReadWriteCloser, key []byte) (io.ReadWriteCloser, error) {
-	w, err := crypto.NewWriter(rwc, key)
+func WithEncryption(rwc io.ReadWriteCloser, key []byte, aead bool) (io.ReadWriteCloser, error) {
+	w, err := crypto.NewWriter(rwc, key, aead)
 	if err != nil {
 		return nil, err
 	}
-	return WrapReadWriteCloser(crypto.NewReader(rwc, key), w, func() error {
+	return WrapReadWriteCloser(crypto.NewReader(rwc, key, aead), w, func() error {
 		return rwc.Close()
 	}), nil
 }

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -123,9 +123,9 @@ func TestWithEncryption(t *testing.T) {
 	conn5 := WrapReadWriteCloser(pr5, pw6, nil)
 	conn6 := WrapReadWriteCloser(pr6, pw5, nil)
 
-	encryptStream1, err := WithEncryption(conn3, []byte(key))
+	encryptStream1, err := WithEncryption(conn3, []byte(key), false)
 	assert.NoError(err)
-	encryptStream2, err := WithEncryption(conn4, []byte(key))
+	encryptStream2, err := WithEncryption(conn4, []byte(key), false)
 	assert.NoError(err)
 
 	go Join(conn2, encryptStream1)

--- a/msg/json/process.go
+++ b/msg/json/process.go
@@ -38,6 +38,7 @@ func (msgCtl *MsgCtl) readMsg(c io.Reader) (typeByte byte, buffer []byte, err er
 		err = ErrMsgType
 		return
 	}
+
 	var length int64
 	err = binary.Read(c, binary.BigEndian, &length)
 	if err != nil {

--- a/msg/json/process.go
+++ b/msg/json/process.go
@@ -38,7 +38,6 @@ func (msgCtl *MsgCtl) readMsg(c io.Reader) (typeByte byte, buffer []byte, err er
 		err = ErrMsgType
 		return
 	}
-
 	var length int64
 	err = binary.Read(c, binary.BigEndian, &length)
 	if err != nil {


### PR DESCRIPTION
As we all know, stream encryption is vulnerable and recognizable. Compared with that, AEAD is more difficult to break and is a mainstream encryption method.

This commit enables golib to support the AEAD method (currently only aes-gcm) and allows us to use it in frp.