### PR TITLE
net/stun: add minimal STUN client

### DIFF
--- a/net/stun/address.go
+++ b/net/stun/address.go
@@ -1,0 +1,117 @@
+// Copyright 2026 fatedier, fatedier@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stun
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"unicode/utf8"
+)
+
+const (
+	addressFamilyIPv4  = 0x01
+	addressFamilyIPv6  = 0x02
+	maxErrorReasonSize = 763
+)
+
+func decodeBindingSuccess(m Message) (BindingResponse, error) {
+	var response BindingResponse
+	var err error
+
+	if value, ok := m.firstAttribute(attrXORMappedAddress); ok {
+		response.MappedAddr, err = decodeAddress(value, m.transactionID, true)
+	} else if value, ok := m.firstAttribute(attrMappedAddress); ok {
+		response.MappedAddr, err = decodeAddress(value, m.transactionID, false)
+	}
+	if err != nil {
+		return BindingResponse{}, err
+	}
+
+	if value, ok := m.firstAttribute(attrOtherAddress); ok {
+		response.OtherAddr, err = decodeAddress(value, m.transactionID, false)
+	} else if value, ok := m.firstAttribute(attrChangedAddress); ok {
+		response.OtherAddr, err = decodeAddress(value, m.transactionID, false)
+	}
+	if err != nil {
+		return BindingResponse{}, err
+	}
+	return response, nil
+}
+
+func decodeAddress(value []byte, id transactionID, xor bool) (*net.UDPAddr, error) {
+	if len(value) < 4 {
+		return nil, malformedResponsef("address attribute is %d bytes, want at least 4", len(value))
+	}
+	var header [4]byte
+	copy(header[:], value)
+
+	var ipLength int
+	family := header[1]
+	switch family {
+	case addressFamilyIPv4:
+		ipLength = net.IPv4len
+	case addressFamilyIPv6:
+		ipLength = net.IPv6len
+	default:
+		return nil, fmt.Errorf("%w: 0x%02x", ErrUnsupportedAddressFamily, family)
+	}
+	if len(value) != 4+ipLength {
+		return nil, malformedResponsef("address family 0x%02x has value length %d, want %d", family, len(value), 4+ipLength)
+	}
+
+	port := binary.BigEndian.Uint16(header[2:4])
+	addressBytes := value[4 : 4+ipLength] //nolint:gosec // The exact value length is checked above.
+	ip := append(net.IP(nil), addressBytes...)
+	if xor {
+		port ^= uint16(magicCookie >> 16)
+		var mask [net.IPv6len]byte
+		binary.BigEndian.PutUint32(mask[0:4], magicCookie)
+		copy(mask[4:], id[:])
+		for i := range ip {
+			ip[i] ^= mask[i]
+		}
+	}
+	return &net.UDPAddr{IP: ip, Port: int(port)}, nil
+}
+
+func decodeBindingError(m Message) error {
+	value, ok := m.firstAttribute(attrErrorCode)
+	if !ok {
+		return malformedResponsef("Binding error response has no ERROR-CODE attribute")
+	}
+	if len(value) < 4 {
+		return malformedResponsef("ERROR-CODE attribute is %d bytes, want at least 4", len(value))
+	}
+	if len(value)-4 > maxErrorReasonSize {
+		return malformedResponsef("ERROR-CODE reason is %d bytes, want at most %d", len(value)-4, maxErrorReasonSize)
+	}
+	reason := value[4:]
+	if !utf8.Valid(reason) {
+		return malformedResponsef("ERROR-CODE reason is not valid UTF-8")
+	}
+	if runeCount := utf8.RuneCount(reason); runeCount >= 128 {
+		return malformedResponsef("ERROR-CODE reason is %d characters, want fewer than 128", runeCount)
+	}
+	class := int(value[2] & 0x07)
+	number := int(value[3])
+	if class < 3 || class > 6 || number > 99 {
+		return malformedResponsef("invalid ERROR-CODE class %d number %d", class, number)
+	}
+	return &ResponseError{
+		Code:   class*100 + number,
+		Reason: string(reason),
+	}
+}

--- a/net/stun/address_test.go
+++ b/net/stun/address_test.go
@@ -1,0 +1,283 @@
+package stun
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func plainAddressValue(ip net.IP, port int) []byte {
+	if ip4 := ip.To4(); ip4 != nil {
+		value := make([]byte, 4+net.IPv4len)
+		value[1] = addressFamilyIPv4
+		binary.BigEndian.PutUint16(value[2:4], uint16(port))
+		copy(value[4:], ip4)
+		return value
+	}
+	value := make([]byte, 4+net.IPv6len)
+	value[1] = addressFamilyIPv6
+	binary.BigEndian.PutUint16(value[2:4], uint16(port))
+	copy(value[4:], ip.To16())
+	return value
+}
+
+func xorAddressValue(ip net.IP, port int, id transactionID) []byte {
+	value := plainAddressValue(ip, port)
+	binary.BigEndian.PutUint16(value[2:4], binary.BigEndian.Uint16(value[2:4])^uint16(magicCookie>>16))
+	var mask [net.IPv6len]byte
+	binary.BigEndian.PutUint32(mask[:4], magicCookie)
+	copy(mask[4:], id[:])
+	for i := 4; i < len(value); i++ {
+		value[i] ^= mask[i-4]
+	}
+	return value
+}
+
+func TestDecodeLegacyAndModernAddresses(t *testing.T) {
+	id := transactionID{0xb7, 0xe7, 0xa7, 0x01, 0xbc, 0x34, 0xd6, 0x86, 0xfa, 0x87, 0xdf, 0xae}
+
+	t.Run("legacy IPv4", func(t *testing.T) {
+		packet := makeTestMessage(bindingSuccess, id,
+			testAttribute{typ: attrMappedAddress, value: plainAddressValue(net.ParseIP("198.51.100.7"), 40000)},
+			testAttribute{typ: attrChangedAddress, value: plainAddressValue(net.ParseIP("203.0.113.8"), 3479)},
+		)
+		m, err := parseMessage(packet)
+		require.NoError(t, err)
+		response, err := decodeBindingSuccess(m)
+		require.NoError(t, err)
+		require.Equal(t, "198.51.100.7:40000", response.MappedAddr.String())
+		require.Equal(t, "203.0.113.8:3479", response.OtherAddr.String())
+	})
+
+	t.Run("modern precedence", func(t *testing.T) {
+		packet := makeTestMessage(bindingSuccess, id,
+			testAttribute{typ: attrMappedAddress, value: plainAddressValue(net.ParseIP("192.0.2.1"), 1000)},
+			testAttribute{typ: attrXORMappedAddress, value: xorAddressValue(net.ParseIP("198.51.100.2"), 2000, id)},
+			testAttribute{typ: attrChangedAddress, value: plainAddressValue(net.ParseIP("192.0.2.3"), 3000)},
+			testAttribute{typ: attrOtherAddress, value: plainAddressValue(net.ParseIP("198.51.100.4"), 4000)},
+		)
+		m, err := parseMessage(packet)
+		require.NoError(t, err)
+		response, err := decodeBindingSuccess(m)
+		require.NoError(t, err)
+		require.Equal(t, "198.51.100.2:2000", response.MappedAddr.String())
+		require.Equal(t, "198.51.100.4:4000", response.OtherAddr.String())
+	})
+
+	t.Run("plain IPv6", func(t *testing.T) {
+		mappedIP := net.ParseIP("2001:db8::10")
+		otherIP := net.ParseIP("2001:db8::20")
+		packet := makeTestMessage(bindingSuccess, id,
+			testAttribute{typ: attrMappedAddress, value: plainAddressValue(mappedIP, 5000)},
+			testAttribute{typ: attrOtherAddress, value: plainAddressValue(otherIP, 5001)},
+		)
+		m, err := parseMessage(packet)
+		require.NoError(t, err)
+		response, err := decodeBindingSuccess(m)
+		require.NoError(t, err)
+		require.True(t, response.MappedAddr.IP.Equal(mappedIP))
+		require.Equal(t, 5000, response.MappedAddr.Port)
+		require.True(t, response.OtherAddr.IP.Equal(otherIP))
+		require.Equal(t, 5001, response.OtherAddr.Port)
+	})
+
+	t.Run("missing addresses", func(t *testing.T) {
+		m, err := parseMessage(makeTestMessage(bindingSuccess, id))
+		require.NoError(t, err)
+		response, err := decodeBindingSuccess(m)
+		require.NoError(t, err)
+		require.Nil(t, response.MappedAddr)
+		require.Nil(t, response.OtherAddr)
+	})
+}
+
+func TestFirstDuplicateWinsAndAllTLVsRemainStructural(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	packet := makeTestMessage(bindingSuccess, id,
+		testAttribute{typ: attrMappedAddress, value: plainAddressValue(net.ParseIP("192.0.2.1"), 1000)},
+		testAttribute{typ: attrMappedAddress, value: plainAddressValue(net.ParseIP("192.0.2.2"), 2000)},
+	)
+	m, err := parseMessage(packet)
+	require.NoError(t, err)
+	response, err := decodeBindingSuccess(m)
+	require.NoError(t, err)
+	require.Equal(t, "192.0.2.1:1000", response.MappedAddr.String())
+
+	malformedDuplicate := append([]byte(nil), packet...)
+	secondOffset := messageHeaderSize + attributeHeaderSize + len(plainAddressValue(net.IPv4zero, 0))
+	binary.BigEndian.PutUint16(malformedDuplicate[secondOffset+2:secondOffset+4], 100)
+	_, err = parseMessage(malformedDuplicate)
+	require.ErrorIs(t, err, ErrMalformedResponse)
+}
+
+func TestPreferredAddressControlsValidation(t *testing.T) {
+	id := transactionID{1, 2, 3}
+
+	t.Run("valid preferred ignores malformed fallback", func(t *testing.T) {
+		packet := makeTestMessage(bindingSuccess, id,
+			testAttribute{typ: attrMappedAddress, value: []byte{0, addressFamilyIPv4, 0, 1}},
+			testAttribute{typ: attrXORMappedAddress, value: xorAddressValue(net.ParseIP("192.0.2.8"), 8080, id)},
+		)
+		m, err := parseMessage(packet)
+		require.NoError(t, err)
+		response, err := decodeBindingSuccess(m)
+		require.NoError(t, err)
+		require.Equal(t, "192.0.2.8:8080", response.MappedAddr.String())
+	})
+
+	t.Run("malformed preferred does not fall back", func(t *testing.T) {
+		packet := makeTestMessage(bindingSuccess, id,
+			testAttribute{typ: attrMappedAddress, value: plainAddressValue(net.ParseIP("192.0.2.9"), 9090)},
+			testAttribute{typ: attrXORMappedAddress, value: []byte{0, addressFamilyIPv4, 0, 1}},
+		)
+		m, err := parseMessage(packet)
+		require.NoError(t, err)
+		_, err = decodeBindingSuccess(m)
+		require.ErrorIs(t, err, ErrMalformedResponse)
+	})
+}
+
+func TestDecodeAddressErrors(t *testing.T) {
+	id := transactionID{}
+
+	_, err := decodeAddress([]byte{0, addressFamilyIPv4, 0}, id, false)
+	require.ErrorIs(t, err, ErrMalformedResponse)
+
+	_, err = decodeAddress([]byte{0, 0x7f, 0, 1}, id, false)
+	require.ErrorIs(t, err, ErrUnsupportedAddressFamily)
+
+	_, err = decodeAddress([]byte{0, addressFamilyIPv6, 0, 1, 1, 2, 3, 4}, id, false)
+	require.ErrorIs(t, err, ErrMalformedResponse)
+}
+
+func TestDecodeAddressIgnoresReservedOctet(t *testing.T) {
+	id := transactionID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	tests := []struct {
+		name string
+		ip   net.IP
+		port int
+		xor  bool
+	}{
+		{name: "plain IPv4", ip: net.ParseIP("198.51.100.10"), port: 41000},
+		{name: "plain IPv6", ip: net.ParseIP("2001:db8::10"), port: 41001},
+		{name: "XOR IPv4", ip: net.ParseIP("198.51.100.11"), port: 41002, xor: true},
+		{name: "XOR IPv6", ip: net.ParseIP("2001:db8::11"), port: 41003, xor: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := plainAddressValue(tt.ip, tt.port)
+			if tt.xor {
+				value = xorAddressValue(tt.ip, tt.port, id)
+			}
+			value[0] = 0xff
+
+			address, err := decodeAddress(value, id, tt.xor)
+			require.NoError(t, err)
+			require.True(t, address.IP.Equal(tt.ip))
+			require.Equal(t, tt.port, address.Port)
+		})
+	}
+}
+
+func TestDecodeBindingError(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	packet := makeTestMessage(bindingError, id,
+		testAttribute{typ: 0x7777, value: []byte("ignored")},
+		testAttribute{typ: attrErrorCode, value: []byte{0, 0, 4, 20, 'U', 'n', 'k', 'n', 'o', 'w', 'n'}},
+		testAttribute{typ: attrErrorCode, value: []byte{0, 0, 5, 0}},
+	)
+	m, err := parseMessage(packet)
+	require.NoError(t, err)
+	err = decodeBindingError(m)
+	var responseErr *ResponseError
+	require.ErrorAs(t, err, &responseErr)
+	require.Equal(t, 420, responseErr.Code)
+	require.Equal(t, "Unknown", responseErr.Reason)
+	require.Equal(t, "STUN binding error 420: Unknown", responseErr.Error())
+}
+
+func TestDecodeBindingErrorIgnoresReservedBits(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	packet := makeTestMessage(bindingError, id, testAttribute{
+		typ:   attrErrorCode,
+		value: []byte{0xab, 0xcd, 0xfc, 20, 'U', 'n', 'k', 'n', 'o', 'w', 'n'},
+	})
+	m, err := parseMessage(packet)
+	require.NoError(t, err)
+	err = decodeBindingError(m)
+	var responseErr *ResponseError
+	require.ErrorAs(t, err, &responseErr)
+	require.Equal(t, 420, responseErr.Code)
+	require.Equal(t, "Unknown", responseErr.Reason)
+}
+
+func TestDecodeBindingErrorReasonPhrase(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	tests := []struct {
+		name          string
+		reason        []byte
+		wantMalformed bool
+		wantReason    string
+	}{
+		{name: "invalid UTF-8", reason: []byte{0xff}, wantMalformed: true},
+		{name: "128 ASCII characters", reason: []byte(strings.Repeat("a", 128)), wantMalformed: true},
+		{name: "127 multibyte characters", reason: []byte(strings.Repeat("\u754c", 127)), wantReason: strings.Repeat("\u754c", 127)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := append([]byte{0, 0, 4, 20}, tt.reason...)
+			m, err := parseMessage(makeTestMessage(bindingError, id, testAttribute{typ: attrErrorCode, value: value}))
+			require.NoError(t, err)
+			err = decodeBindingError(m)
+			if tt.wantMalformed {
+				require.ErrorIs(t, err, ErrMalformedResponse)
+				var responseErr *ResponseError
+				require.False(t, errors.As(err, &responseErr))
+				return
+			}
+
+			var responseErr *ResponseError
+			require.ErrorAs(t, err, &responseErr)
+			require.Equal(t, 420, responseErr.Code)
+			require.Equal(t, tt.wantReason, responseErr.Reason)
+		})
+	}
+}
+
+func TestDecodeBindingErrorRejectsMalformedErrorCode(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	tests := []struct {
+		name       string
+		attributes []testAttribute
+	}{
+		{name: "missing"},
+		{name: "short", attributes: []testAttribute{{typ: attrErrorCode, value: []byte{0, 0, 4}}}},
+		{name: "class", attributes: []testAttribute{{typ: attrErrorCode, value: []byte{0, 0, 2, 0}}}},
+		{name: "number", attributes: []testAttribute{{typ: attrErrorCode, value: []byte{0, 0, 4, 100}}}},
+		{name: "reason too long", attributes: []testAttribute{{
+			typ:   attrErrorCode,
+			value: append([]byte{0, 0, 4, 0}, make([]byte, maxErrorReasonSize+1)...),
+		}}},
+		{name: "invalid first duplicate", attributes: []testAttribute{
+			{typ: attrErrorCode, value: []byte{0, 0, 2, 0}},
+			{typ: attrErrorCode, value: []byte{0, 0, 4, 0}},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := parseMessage(makeTestMessage(bindingError, id, tt.attributes...))
+			require.NoError(t, err)
+			err = decodeBindingError(m)
+			require.ErrorIs(t, err, ErrMalformedResponse)
+			var responseErr *ResponseError
+			require.False(t, errors.As(err, &responseErr))
+		})
+	}
+}

--- a/net/stun/binding.go
+++ b/net/stun/binding.go
@@ -1,0 +1,274 @@
+// Copyright 2026 fatedier, fatedier@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stun
+
+import (
+	"crypto/rand"
+	"encoding"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+)
+
+const maxUDPPacketSize = 64 * 1024
+
+// BindingResponse contains addresses returned by a successful Binding
+// transaction. Either field may be nil when the server omitted that address.
+// The addresses do not alias the response datagram.
+type BindingResponse struct {
+	// MappedAddr is the server-observed address of the client.
+	MappedAddr *net.UDPAddr
+	// OtherAddr is the alternate server address advertised by the server.
+	OtherAddr *net.UDPAddr
+}
+
+// Client performs synchronous STUN transactions over a caller-owned UDP
+// connection.
+//
+// A Client borrows its connection: it never closes it, changes its deadlines,
+// retries a request, or starts background goroutines. A Client may be reused
+// sequentially. The caller must ensure that no other goroutine reads from the
+// same connection while Do is running, including through another Client.
+type Client struct {
+	conn *net.UDPConn
+}
+
+// NewClient returns a Client that uses conn for synchronous STUN transactions.
+// The caller retains ownership of conn.
+func NewClient(conn *net.UDPConn) (*Client, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("STUN Client requires a non-nil UDP connection")
+	}
+	return &Client{conn: conn}, nil
+}
+
+// BindingTransaction associates one Binding request with its expected server.
+//
+// It is immutable after construction. MarshalBinary may be called repeatedly
+// and always returns a new request buffer. Process does not mark the
+// transaction complete, so callers own retransmission, timeout, and lifecycle
+// policy. Its methods are safe for concurrent use.
+type BindingTransaction struct {
+	request Message
+	server  net.UDPAddr
+}
+
+var _ encoding.BinaryMarshaler = (*BindingTransaction)(nil)
+
+// NewBindingTransaction creates a Binding transaction for server.
+//
+// The server address, including its IP bytes, is copied. Responses from any
+// other source are considered unrelated to the transaction.
+func NewBindingTransaction(server *net.UDPAddr) (*BindingTransaction, error) {
+	return newBindingTransaction(server, rand.Reader)
+}
+
+func newBindingTransaction(server *net.UDPAddr, entropy io.Reader) (*BindingTransaction, error) {
+	if err := validateServer(server); err != nil {
+		return nil, err
+	}
+	id, err := newTransactionID(entropy)
+	if err != nil {
+		return nil, err
+	}
+	return &BindingTransaction{
+		request: newBindingRequestMessage(id),
+		server:  cloneUDPAddr(server),
+	}, nil
+}
+
+// MarshalBinary returns a new copy of the Binding request datagram.
+func (t *BindingTransaction) MarshalBinary() ([]byte, error) {
+	if t == nil {
+		return nil, fmt.Errorf("cannot marshal a nil STUN BindingTransaction")
+	}
+	return t.request.MarshalBinary()
+}
+
+// TransactionID returns the transaction's 96-bit identifier.
+func (t *BindingTransaction) TransactionID() [12]byte {
+	if t == nil {
+		return [12]byte{}
+	}
+	return t.request.TransactionID()
+}
+
+// Process associates and decodes a caller-received datagram.
+//
+// matched is false with a nil error when source, message type, magic cookie,
+// or transaction ID does not identify this transaction. Once those fields
+// match, matched is true: malformed framing or malformed supported attributes
+// return an error wrapping ErrMalformedResponse, an unsupported address family
+// wraps ErrUnsupportedAddressFamily, and a STUN Binding error returns a
+// *ResponseError. The packet and source address are never retained.
+func (t *BindingTransaction) Process(
+	packet []byte,
+	source *net.UDPAddr,
+) (response BindingResponse, matched bool, err error) {
+	if t == nil {
+		return BindingResponse{}, false, fmt.Errorf("cannot process a response with a nil STUN BindingTransaction")
+	}
+	if !sameUDPAddress(source, &t.server) || !isCorrelatedResponse(packet, t.request.transactionID) {
+		return BindingResponse{}, false, nil
+	}
+
+	var message Message
+	if err := message.UnmarshalBinary(packet); err != nil {
+		return BindingResponse{}, true, err
+	}
+	switch message.typ {
+	case bindingSuccess:
+		response, err := decodeBindingSuccess(message)
+		return response, true, err
+	case bindingError:
+		return BindingResponse{}, true, decodeBindingError(message)
+	default:
+		panic("correlated STUN response has unexpected type")
+	}
+}
+
+// Do performs one synchronous STUN Binding transaction.
+//
+// The transaction's server may be used with an unconnected connection or with
+// a connection connected to that server. Do rejects a different connected
+// peer before sending. It sends exactly one copy returned by t.MarshalBinary,
+// then processes each received datagram with t.Process until one matches.
+// Unrelated datagrams are discarded. Network errors are returned unchanged.
+//
+// Do does not set or restore connection deadlines, retry, close the connection,
+// or mark t complete. The caller must arrange any deadline and serialize all
+// reads from the connection until Do returns.
+func (c *Client) Do(t *BindingTransaction) (BindingResponse, error) {
+	if c == nil {
+		return BindingResponse{}, fmt.Errorf("cannot use a nil STUN Client")
+	}
+	if c.conn == nil {
+		return BindingResponse{}, fmt.Errorf("STUN Client has no UDP connection")
+	}
+	if t == nil {
+		return BindingResponse{}, fmt.Errorf("STUN Client.Do requires a non-nil BindingTransaction")
+	}
+
+	connectedPeer, connected := c.conn.RemoteAddr().(*net.UDPAddr)
+	if connected && !sameUDPAddress(connectedPeer, &t.server) {
+		return BindingResponse{}, fmt.Errorf(
+			"STUN Binding server %s does not match connected UDP peer %s",
+			&t.server,
+			connectedPeer,
+		)
+	}
+
+	request, err := t.MarshalBinary()
+	if err != nil {
+		return BindingResponse{}, err
+	}
+	var n int
+	if connected {
+		n, err = c.conn.Write(request)
+	} else {
+		n, err = c.conn.WriteToUDP(request, &t.server)
+	}
+	if err != nil {
+		return BindingResponse{}, err
+	}
+	if n != len(request) {
+		return BindingResponse{}, io.ErrShortWrite
+	}
+
+	buffer := make([]byte, maxUDPPacketSize)
+	for {
+		n, source, err := c.conn.ReadFromUDP(buffer)
+		if err != nil {
+			return BindingResponse{}, err
+		}
+		response, matched, err := t.Process(buffer[:n], source)
+		if !matched {
+			continue
+		}
+		return response, err
+	}
+}
+
+func validateServer(server *net.UDPAddr) error {
+	if server == nil {
+		return fmt.Errorf("STUN Binding requires a non-nil server address")
+	}
+	if server.IP.To4() == nil && server.IP.To16() == nil {
+		return fmt.Errorf("%w: server address %q", ErrUnsupportedAddressFamily, server.IP)
+	}
+	return nil
+}
+
+func cloneUDPAddr(address *net.UDPAddr) net.UDPAddr {
+	return net.UDPAddr{
+		IP:   append(net.IP(nil), address.IP...),
+		Port: address.Port,
+		Zone: address.Zone,
+	}
+}
+
+func sameUDPAddress(a, b *net.UDPAddr) bool {
+	if a == nil || b == nil || a.Port != b.Port || !a.IP.Equal(b.IP) {
+		return false
+	}
+	if !ipv6NeedsZone(a.IP) || a.Zone == b.Zone {
+		return true
+	}
+	aIndex, aOK := zoneInterfaceIndex(a.Zone)
+	bIndex, bOK := zoneInterfaceIndex(b.Zone)
+	return aOK && bOK && aIndex == bIndex
+}
+
+func ipv6NeedsZone(ip net.IP) bool {
+	if ip.To4() != nil {
+		return false
+	}
+	ip = ip.To16()
+	if ip == nil {
+		return false
+	}
+	if ip.IsLinkLocalUnicast() {
+		return true
+	}
+	if ip[0] != 0xff {
+		return false
+	}
+	// IPv6 multicast encodes its scope in the low nibble of byte 1.
+	// Scope e is global; 0 and f are reserved.
+	scope := ip[1] & 0x0f
+	return scope > 0 && scope < 0x0e
+}
+
+func zoneInterfaceIndex(zone string) (int, bool) {
+	if zone == "" {
+		return 0, true
+	}
+	if iface, err := net.InterfaceByName(zone); err == nil {
+		return iface.Index, true
+	}
+	index, err := strconv.ParseUint(zone, 10, 0)
+	if err != nil || index > uint64(^uint(0)>>1) {
+		return 0, false
+	}
+	if index == 0 {
+		return 0, true
+	}
+	iface, err := net.InterfaceByIndex(int(index))
+	if err != nil {
+		return 0, false
+	}
+	return iface.Index, true
+}

--- a/net/stun/binding_test.go
+++ b/net/stun/binding_test.go
@@ -1,0 +1,834 @@
+package stun
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testSocketTimeout = 2 * time.Second
+
+func listenUDP4(t *testing.T) *net.UDPConn {
+	t.Helper()
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func serveOneBinding(
+	server *net.UDPConn,
+	response func(transactionID, *net.UDPAddr) ([]byte, error),
+) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		if err := server.SetDeadline(time.Now().Add(testSocketTimeout)); err != nil {
+			done <- err
+			return
+		}
+		buffer := make([]byte, 1024)
+		n, clientAddr, err := server.ReadFromUDP(buffer)
+		if err != nil {
+			done <- err
+			return
+		}
+		if n != messageHeaderSize {
+			done <- fmt.Errorf("request is %d bytes, want %d", n, messageHeaderSize)
+			return
+		}
+		if binary.BigEndian.Uint16(buffer[0:2]) != bindingRequest {
+			done <- fmt.Errorf("request has type 0x%04x", binary.BigEndian.Uint16(buffer[0:2]))
+			return
+		}
+		var id transactionID
+		copy(id[:], buffer[8:20])
+		packet, err := response(id, clientAddr)
+		if err == nil {
+			_, err = server.WriteToUDP(packet, clientAddr)
+		}
+		done <- err
+	}()
+	return done
+}
+
+func waitServer(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(testSocketTimeout + time.Second):
+		t.Fatal("timed out waiting for local STUN server")
+	}
+}
+
+func TestClientDropsUnrelatedDatagrams(t *testing.T) {
+	server := listenUDP4(t)
+	foreign := listenUDP4(t)
+	conn := listenUDP4(t)
+	serverAddr := server.LocalAddr().(*net.UDPAddr)
+
+	done := serveOneBinding(server, func(id transactionID, clientAddr *net.UDPAddr) ([]byte, error) {
+		mapped := testAttribute{
+			typ:   attrXORMappedAddress,
+			value: xorAddressValue(net.ParseIP("198.51.100.42"), 45678, id),
+		}
+		valid := makeTestMessage(bindingSuccess, id, mapped)
+
+		if _, err := foreign.WriteToUDP(valid, clientAddr); err != nil {
+			return nil, err
+		}
+		if _, err := server.WriteToUDP([]byte{0, 1, 2}, clientAddr); err != nil {
+			return nil, err
+		}
+		wrongCookie := append([]byte(nil), valid...)
+		wrongCookie[4] ^= 1
+		if _, err := server.WriteToUDP(wrongCookie, clientAddr); err != nil {
+			return nil, err
+		}
+		wrongID := append([]byte(nil), valid...)
+		wrongID[8] ^= 1
+		if _, err := server.WriteToUDP(wrongID, clientAddr); err != nil {
+			return nil, err
+		}
+		wrongType := append([]byte(nil), valid...)
+		binary.BigEndian.PutUint16(wrongType[0:2], bindingRequest)
+		if _, err := server.WriteToUDP(wrongType, clientAddr); err != nil {
+			return nil, err
+		}
+		wrongMethod := append([]byte(nil), valid...)
+		binary.BigEndian.PutUint16(wrongMethod[0:2], 0x0103)
+		if _, err := server.WriteToUDP(wrongMethod, clientAddr); err != nil {
+			return nil, err
+		}
+		return valid, nil
+	})
+
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	transaction, err := NewBindingTransaction(serverAddr)
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(testSocketTimeout)))
+	response, err := client.Do(transaction)
+	require.NoError(t, err)
+	require.Equal(t, "198.51.100.42:45678", response.MappedAddr.String())
+	waitServer(t, done)
+}
+
+func TestBindingTransactionRequestAndServerOwnership(t *testing.T) {
+	id := transactionID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	server := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 10), Port: 3478}
+	expectedSource := cloneUDPAddr(server)
+	transaction, err := newBindingTransaction(server, bytes.NewReader(id[:]))
+	require.NoError(t, err)
+
+	var marshaler encoding.BinaryMarshaler = transaction
+	first, err := marshaler.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, [12]byte(id), transaction.TransactionID())
+	require.Equal(t, "000100002112a442000102030405060708090a0b", fmt.Sprintf("%x", first))
+	first[0] ^= 0xff
+	second, err := transaction.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, "000100002112a442000102030405060708090a0b", fmt.Sprintf("%x", second))
+
+	server.IP[0] ^= 0xff
+	server.Port++
+	packet := makeTestMessage(bindingSuccess, id, testAttribute{
+		typ:   attrMappedAddress,
+		value: plainAddressValue(net.ParseIP("198.51.100.20"), 40000),
+	})
+	response, matched, err := transaction.Process(packet, &expectedSource)
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, "198.51.100.20:40000", response.MappedAddr.String())
+
+	for i := range packet {
+		packet[i] ^= 0xff
+	}
+	require.Equal(t, "198.51.100.20:40000", response.MappedAddr.String())
+}
+
+func TestBindingTransactionConcurrentMethods(t *testing.T) {
+	id := transactionID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	server := &net.UDPAddr{IP: net.ParseIP("2001:db8::10"), Port: 3478}
+	transaction, err := newBindingTransaction(server, bytes.NewReader(id[:]))
+	require.NoError(t, err)
+	packet := makeTestMessage(bindingSuccess, id, testAttribute{
+		typ:   attrMappedAddress,
+		value: plainAddressValue(net.ParseIP("198.51.100.20"), 40000),
+	})
+	wantRequest := buildBindingRequest(id)
+
+	const callsPerMethod = 32
+	start := make(chan struct{})
+	results := make(chan error, callsPerMethod*3)
+	var workers sync.WaitGroup
+	workers.Add(callsPerMethod * 3)
+	for range callsPerMethod {
+		go func() {
+			defer workers.Done()
+			<-start
+			request, err := transaction.MarshalBinary()
+			if err == nil && !bytes.Equal(request, wantRequest[:]) {
+				err = fmt.Errorf("MarshalBinary returned %x, want %x", request, wantRequest)
+			}
+			results <- err
+		}()
+		go func() {
+			defer workers.Done()
+			<-start
+			if got := transaction.TransactionID(); got != [12]byte(id) {
+				results <- fmt.Errorf("TransactionID returned %x, want %x", got, id)
+				return
+			}
+			results <- nil
+		}()
+		go func() {
+			defer workers.Done()
+			<-start
+			response, matched, err := transaction.Process(packet, server)
+			if err == nil && !matched {
+				err = errors.New("Process did not match the response")
+			}
+			if err == nil && (response.MappedAddr == nil || response.MappedAddr.String() != "198.51.100.20:40000") {
+				err = fmt.Errorf("Process returned mapped address %v", response.MappedAddr)
+			}
+			results <- err
+		}()
+	}
+
+	close(start)
+	workers.Wait()
+	close(results)
+	resultCount := 0
+	for err := range results {
+		require.NoError(t, err)
+		resultCount++
+	}
+	require.Equal(t, callsPerMethod*3, resultCount)
+}
+
+func TestBindingTransactionClassifiesDatagrams(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	server := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3478}
+	transaction, err := newBindingTransaction(server, bytes.NewReader(id[:]))
+	require.NoError(t, err)
+	valid := makeTestMessage(bindingSuccess, id, testAttribute{
+		typ:   attrXORMappedAddress,
+		value: xorAddressValue(net.ParseIP("198.51.100.30"), 41000, id),
+	})
+
+	tests := []struct {
+		name   string
+		packet []byte
+		source *net.UDPAddr
+	}{
+		{name: "nil source", packet: valid},
+		{name: "source IP", packet: valid, source: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 2), Port: server.Port}},
+		{name: "source port", packet: valid, source: &net.UDPAddr{IP: server.IP, Port: server.Port + 1}},
+		{name: "short", packet: valid[:messageHeaderSize-1], source: server},
+		{name: "request type", packet: func() []byte {
+			packet := append([]byte(nil), valid...)
+			binary.BigEndian.PutUint16(packet[0:2], bindingRequest)
+			return packet
+		}(), source: server},
+		{name: "cookie", packet: func() []byte {
+			packet := append([]byte(nil), valid...)
+			packet[4] ^= 1
+			return packet
+		}(), source: server},
+		{name: "transaction ID", packet: func() []byte {
+			packet := append([]byte(nil), valid...)
+			packet[8] ^= 1
+			return packet
+		}(), source: server},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, matched, err := transaction.Process(tt.packet, tt.source)
+			require.NoError(t, err)
+			require.False(t, matched)
+			require.Equal(t, BindingResponse{}, response)
+		})
+	}
+
+	response, matched, err := transaction.Process(valid, &net.UDPAddr{
+		IP:   server.IP,
+		Port: server.Port,
+		Zone: "ignored-for-ipv4",
+	})
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, "198.51.100.30:41000", response.MappedAddr.String())
+
+	response, matched, err = transaction.Process(valid, server)
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, "198.51.100.30:41000", response.MappedAddr.String())
+}
+
+func TestBindingTransactionProcessMatchesScopeZeroZone(t *testing.T) {
+	if iface, err := net.InterfaceByName("0"); err == nil {
+		t.Skipf("interface %q has index %d and takes precedence over numeric zone parsing", iface.Name, iface.Index)
+	}
+
+	id := transactionID{1, 2, 3}
+	packet := makeTestMessage(bindingSuccess, id)
+	tests := []struct {
+		name       string
+		ip         net.IP
+		serverZone string
+		sourceZone string
+	}{
+		{name: "scoped unicast empty to zero", ip: net.ParseIP("fe80::1"), sourceZone: "0"},
+		{name: "scoped unicast zero to empty", ip: net.ParseIP("fe80::1"), serverZone: "0"},
+		{name: "scoped multicast empty to zero", ip: net.ParseIP("ff02::1"), sourceZone: "0"},
+		{name: "scoped multicast zero to empty", ip: net.ParseIP("ff02::1"), serverZone: "0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &net.UDPAddr{IP: tt.ip, Port: 3478, Zone: tt.serverZone}
+			transaction, err := newBindingTransaction(server, bytes.NewReader(id[:]))
+			require.NoError(t, err)
+			response, matched, err := transaction.Process(packet, &net.UDPAddr{
+				IP:   tt.ip,
+				Port: server.Port,
+				Zone: tt.sourceZone,
+			})
+			require.NoError(t, err)
+			require.True(t, matched)
+			require.Equal(t, BindingResponse{}, response)
+		})
+	}
+}
+
+func TestNewBindingTransactionValidatesServer(t *testing.T) {
+	_, err := NewBindingTransaction(nil)
+	require.Error(t, err)
+
+	_, err = NewBindingTransaction(&net.UDPAddr{IP: net.IP{1, 2, 3}, Port: 3478})
+	require.ErrorIs(t, err, ErrUnsupportedAddressFamily)
+}
+
+func TestBindingTransactionRelatedMalformedAndErrorResponses(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	server := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3478}
+	transaction, err := newBindingTransaction(server, bytes.NewReader(id[:]))
+	require.NoError(t, err)
+
+	malformed := append(makeTestMessage(bindingSuccess, id), 0, 0, 0, 0)
+	_, matched, err := transaction.Process(malformed, server)
+	require.True(t, matched)
+	require.ErrorIs(t, err, ErrMalformedResponse)
+
+	_, matched, err = transaction.Process(malformed, &net.UDPAddr{IP: server.IP, Port: server.Port + 1})
+	require.False(t, matched)
+	require.NoError(t, err)
+
+	errorPacket := makeTestMessage(bindingError, id, testAttribute{
+		typ:   attrErrorCode,
+		value: []byte{0, 0, 4, 20, 'U', 'n', 'k', 'n', 'o', 'w', 'n'},
+	})
+	_, matched, err = transaction.Process(errorPacket, server)
+	require.True(t, matched)
+	var responseErr *ResponseError
+	require.ErrorAs(t, err, &responseErr)
+	require.Equal(t, 420, responseErr.Code)
+}
+
+func TestCallerManagedIOAndClientUseSameSemantics(t *testing.T) {
+	server := listenUDP4(t)
+	conn := listenUDP4(t)
+	serverAddr := server.LocalAddr().(*net.UDPAddr)
+	responsePacket := func(id transactionID, _ *net.UDPAddr) ([]byte, error) {
+		return makeTestMessage(bindingSuccess, id,
+			testAttribute{
+				typ:   attrMappedAddress,
+				value: plainAddressValue(net.ParseIP("192.0.2.1"), 1000),
+			},
+			testAttribute{
+				typ:   attrXORMappedAddress,
+				value: xorAddressValue(net.ParseIP("198.51.100.40"), 42000, id),
+			},
+		), nil
+	}
+
+	lowLevelDone := serveOneBinding(server, responsePacket)
+	transaction, err := NewBindingTransaction(serverAddr)
+	require.NoError(t, err)
+	request, err := transaction.MarshalBinary()
+	require.NoError(t, err)
+	_, err = conn.WriteToUDP(request, serverAddr)
+	require.NoError(t, err)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(testSocketTimeout)))
+	buffer := make([]byte, 1024)
+	n, source, err := conn.ReadFromUDP(buffer)
+	require.NoError(t, err)
+	lowLevelResponse, matched, err := transaction.Process(buffer[:n], source)
+	require.NoError(t, err)
+	require.True(t, matched)
+	waitServer(t, lowLevelDone)
+
+	highLevelDone := serveOneBinding(server, responsePacket)
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	highLevelTransaction, err := NewBindingTransaction(serverAddr)
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(testSocketTimeout)))
+	highLevelResponse, err := client.Do(highLevelTransaction)
+	require.NoError(t, err)
+	waitServer(t, highLevelDone)
+
+	require.Equal(t, lowLevelResponse.MappedAddr.String(), highLevelResponse.MappedAddr.String())
+	require.Equal(t, "198.51.100.40:42000", highLevelResponse.MappedAddr.String())
+}
+
+func TestClientDoAndTransactionProcessHaveEquivalentSemantics(t *testing.T) {
+	tests := []struct {
+		name   string
+		packet func(transactionID) []byte
+	}{
+		{
+			name: "success",
+			packet: func(id transactionID) []byte {
+				return makeTestMessage(bindingSuccess, id, testAttribute{
+					typ:   attrXORMappedAddress,
+					value: xorAddressValue(net.ParseIP("198.51.100.44"), 43000, id),
+				})
+			},
+		},
+		{
+			name: "Binding error",
+			packet: func(id transactionID) []byte {
+				return makeTestMessage(bindingError, id, testAttribute{
+					typ:   attrErrorCode,
+					value: []byte{0, 0, 4, 20, 'U', 'n', 'k', 'n', 'o', 'w', 'n'},
+				})
+			},
+		},
+		{
+			name: "correlated malformed response",
+			packet: func(id transactionID) []byte {
+				return append(makeTestMessage(bindingSuccess, id), 0, 0, 0, 0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := listenUDP4(t)
+			serverAddr := server.LocalAddr().(*net.UDPAddr)
+
+			directTransaction, err := NewBindingTransaction(serverAddr)
+			require.NoError(t, err)
+			directResponse, matched, directErr := directTransaction.Process(
+				tt.packet(transactionID(directTransaction.TransactionID())),
+				serverAddr,
+			)
+			require.True(t, matched)
+
+			done := serveOneBinding(server, func(id transactionID, _ *net.UDPAddr) ([]byte, error) {
+				return tt.packet(id), nil
+			})
+			conn := listenUDP4(t)
+			client, err := NewClient(conn)
+			require.NoError(t, err)
+			clientTransaction, err := NewBindingTransaction(serverAddr)
+			require.NoError(t, err)
+			require.NoError(t, conn.SetDeadline(time.Now().Add(testSocketTimeout)))
+			clientResponse, clientErr := client.Do(clientTransaction)
+			waitServer(t, done)
+
+			require.Equal(t, directResponse, clientResponse)
+			require.Equal(t, fmt.Sprintf("%T", directErr), fmt.Sprintf("%T", clientErr))
+			if directErr == nil {
+				require.NoError(t, clientErr)
+				return
+			}
+			require.EqualError(t, clientErr, directErr.Error())
+		})
+	}
+}
+
+func TestClientSupportsConnectedMatchingPeer(t *testing.T) {
+	server := listenUDP4(t)
+	serverAddr := server.LocalAddr().(*net.UDPAddr)
+	conn, err := net.DialUDP("udp4", nil, serverAddr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	done := serveOneBinding(server, func(id transactionID, _ *net.UDPAddr) ([]byte, error) {
+		return makeTestMessage(bindingSuccess, id, testAttribute{
+			typ:   attrXORMappedAddress,
+			value: xorAddressValue(net.ParseIP("198.51.100.43"), 45679, id),
+		}), nil
+	})
+
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	serverWithZone := cloneUDPAddr(serverAddr)
+	serverWithZone.Zone = "ignored-for-ipv4"
+	transaction, err := NewBindingTransaction(&serverWithZone)
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(testSocketTimeout)))
+	response, err := client.Do(transaction)
+	require.NoError(t, err)
+	require.Equal(t, "198.51.100.43:45679", response.MappedAddr.String())
+	waitServer(t, done)
+}
+
+func TestSameUDPAddressZones(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *net.UDPAddr
+		b    *net.UDPAddr
+		want bool
+	}{
+		{
+			name: "IPv4 ignores zone",
+			a:    &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478, Zone: "first"},
+			b:    &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 3478, Zone: "second"},
+			want: true,
+		},
+		{
+			name: "global IPv6 ignores zone",
+			a:    &net.UDPAddr{IP: net.ParseIP("2001:db8::1"), Port: 3478, Zone: "first"},
+			b:    &net.UDPAddr{IP: net.ParseIP("2001:db8::1"), Port: 3478, Zone: "second"},
+			want: true,
+		},
+		{
+			name: "global IPv6 multicast ignores zone",
+			a:    &net.UDPAddr{IP: net.ParseIP("ff0e::1"), Port: 3478, Zone: "first"},
+			b:    &net.UDPAddr{IP: net.ParseIP("ff0e::1"), Port: 3478, Zone: "second"},
+			want: true,
+		},
+		{
+			name: "scoped IPv6 same zone",
+			a:    &net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 3478, Zone: "same"},
+			b:    &net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 3478, Zone: "same"},
+			want: true,
+		},
+		{
+			name: "scoped IPv6 different zone",
+			a:    &net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 3478},
+			b:    &net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 3478, Zone: "\x00"},
+			want: false,
+		},
+		{
+			name: "scoped IPv6 multicast different zone",
+			a:    &net.UDPAddr{IP: net.ParseIP("ff02::1"), Port: 3478},
+			b:    &net.UDPAddr{IP: net.ParseIP("ff02::1"), Port: 3478, Zone: "\x00"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, sameUDPAddress(tt.a, tt.b))
+			require.Equal(t, tt.want, sameUDPAddress(tt.b, tt.a))
+		})
+	}
+}
+
+func TestSameUDPAddressIPv4Representations(t *testing.T) {
+	ipv4 := net.ParseIP("192.0.2.1").To4()
+	mapped := net.ParseIP("192.0.2.1")
+	require.Len(t, ipv4, net.IPv4len)
+	require.Len(t, mapped, net.IPv6len)
+
+	a := &net.UDPAddr{IP: ipv4, Port: 3478, Zone: "first"}
+	b := &net.UDPAddr{IP: mapped, Port: 3478, Zone: "second"}
+	require.True(t, sameUDPAddress(a, b))
+	require.True(t, sameUDPAddress(b, a))
+}
+
+func TestSameUDPAddressScopeZeroZones(t *testing.T) {
+	if iface, err := net.InterfaceByName("0"); err == nil {
+		t.Skipf("interface %q has index %d and takes precedence over numeric zone parsing", iface.Name, iface.Index)
+	}
+
+	for _, tt := range []struct {
+		name string
+		ip   net.IP
+	}{
+		{name: "scoped unicast", ip: net.ParseIP("fe80::1")},
+		{name: "scoped multicast", ip: net.ParseIP("ff02::1")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			emptyZone := &net.UDPAddr{IP: tt.ip, Port: 3478}
+			zeroZone := &net.UDPAddr{IP: tt.ip, Port: 3478, Zone: "0"}
+			require.True(t, sameUDPAddress(emptyZone, zeroZone))
+			require.True(t, sameUDPAddress(zeroZone, emptyZone))
+		})
+	}
+}
+
+func TestSameUDPAddressMatchesInterfaceNameAndIndex(t *testing.T) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		t.Skipf("cannot list network interfaces: %v", err)
+	}
+	for _, iface := range interfaces {
+		if iface.Name == "" || iface.Index <= 0 {
+			continue
+		}
+		byName, nameErr := net.InterfaceByName(iface.Name)
+		byIndex, indexErr := net.InterfaceByIndex(iface.Index)
+		if nameErr != nil || indexErr != nil || byName.Index != byIndex.Index {
+			continue
+		}
+		indexZone := fmt.Sprint(iface.Index)
+		if numericName, err := net.InterfaceByName(indexZone); err == nil && numericName.Index != iface.Index {
+			continue
+		}
+		addressByName := &net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 3478, Zone: iface.Name}
+		addressByIndex := &net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 3478, Zone: indexZone}
+		require.True(t, sameUDPAddress(addressByName, addressByIndex))
+		require.True(t, sameUDPAddress(addressByIndex, addressByName))
+		return
+	}
+	t.Skip("no network interface supports both name and index lookup")
+}
+
+func TestClientRejectsConnectedPeerMismatchWithoutSending(t *testing.T) {
+	connectedServer := listenUDP4(t)
+	otherServer := listenUDP4(t)
+	connectedAddr := connectedServer.LocalAddr().(*net.UDPAddr)
+	otherAddr := otherServer.LocalAddr().(*net.UDPAddr)
+	conn, err := net.DialUDP("udp4", nil, connectedAddr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	transaction, err := NewBindingTransaction(otherAddr)
+	require.NoError(t, err)
+	_, err = client.Do(transaction)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match connected UDP peer")
+	require.True(t, sameUDPAddress(conn.RemoteAddr().(*net.UDPAddr), connectedAddr))
+
+	require.NoError(t, connectedServer.SetReadDeadline(time.Now().Add(100*time.Millisecond)))
+	buffer := make([]byte, 1)
+	_, _, err = connectedServer.ReadFromUDP(buffer)
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr)
+	require.True(t, netErr.Timeout())
+
+	// Do neither sent the transaction nor closed the caller-owned connection.
+	require.NoError(t, connectedServer.SetReadDeadline(time.Now().Add(testSocketTimeout)))
+	_, err = conn.Write([]byte{1})
+	require.NoError(t, err)
+	_, _, err = connectedServer.ReadFromUDP(buffer)
+	require.NoError(t, err)
+}
+
+func TestClientDeadlinePreservesNetErrorAndDoesNotRetry(t *testing.T) {
+	server := listenUDP4(t)
+	conn := listenUDP4(t)
+	serverAddr := server.LocalAddr().(*net.UDPAddr)
+	requestCount := make(chan int, 1)
+
+	go func() {
+		buffer := make([]byte, 1024)
+		if err := server.SetReadDeadline(time.Now().Add(testSocketTimeout)); err != nil {
+			requestCount <- 0
+			return
+		}
+		if _, _, err := server.ReadFromUDP(buffer); err != nil {
+			requestCount <- 0
+			return
+		}
+		count := 1
+		_ = server.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		for {
+			_, _, err := server.ReadFromUDP(buffer)
+			if err != nil {
+				requestCount <- count
+				return
+			}
+			count++
+		}
+	}()
+
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	transaction, err := NewBindingTransaction(serverAddr)
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(250*time.Millisecond)))
+	_, err = client.Do(transaction)
+	require.Error(t, err)
+	var netErr net.Error
+	require.True(t, errors.As(err, &netErr))
+	require.True(t, netErr.Timeout())
+
+	select {
+	case count := <-requestCount:
+		require.Equal(t, 1, count)
+	case <-time.After(testSocketTimeout):
+		t.Fatal("timed out counting Binding requests")
+	}
+
+	readResult := make(chan error, 1)
+	go func() {
+		_, _, readErr := conn.ReadFromUDP(make([]byte, 1))
+		readResult <- readErr
+	}()
+	select {
+	case readErr := <-readResult:
+		var readNetErr net.Error
+		require.ErrorAs(t, readErr, &readNetErr)
+		require.True(t, readNetErr.Timeout())
+	case <-time.After(250 * time.Millisecond):
+		_ = conn.Close()
+		t.Fatal("Client.Do cleared or replaced the caller's deadline")
+	}
+}
+
+func TestClientReturnsTypedResponseError(t *testing.T) {
+	server := listenUDP4(t)
+	conn := listenUDP4(t)
+	done := serveOneBinding(server, func(id transactionID, _ *net.UDPAddr) ([]byte, error) {
+		return makeTestMessage(bindingError, id, testAttribute{
+			typ:   attrErrorCode,
+			value: []byte{0, 0, 5, 0, 'F', 'a', 'i', 'l', 'e', 'd'},
+		}), nil
+	})
+
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	transaction, err := NewBindingTransaction(server.LocalAddr().(*net.UDPAddr))
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(testSocketTimeout)))
+	_, err = client.Do(transaction)
+	var responseErr *ResponseError
+	require.ErrorAs(t, err, &responseErr)
+	require.Equal(t, 500, responseErr.Code)
+	require.Equal(t, "Failed", responseErr.Reason)
+	waitServer(t, done)
+}
+
+func TestClientRejectsCorrelatedMalformedResponse(t *testing.T) {
+	server := listenUDP4(t)
+	conn := listenUDP4(t)
+	done := serveOneBinding(server, func(id transactionID, _ *net.UDPAddr) ([]byte, error) {
+		packet := makeTestMessage(bindingSuccess, id)
+		return append(packet, 0, 0, 0, 0), nil
+	})
+
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	transaction, err := NewBindingTransaction(server.LocalAddr().(*net.UDPAddr))
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(testSocketTimeout)))
+	_, err = client.Do(transaction)
+	require.ErrorIs(t, err, ErrMalformedResponse)
+	waitServer(t, done)
+}
+
+func TestClientReusesSocketAndLocalPortForAlternateServer(t *testing.T) {
+	primary := listenUDP4(t)
+	alternate := listenUDP4(t)
+	conn := listenUDP4(t)
+	primarySource := make(chan *net.UDPAddr, 1)
+	alternateSource := make(chan *net.UDPAddr, 1)
+
+	primaryDone := serveOneBinding(primary, func(id transactionID, clientAddr *net.UDPAddr) ([]byte, error) {
+		primarySource <- clientAddr
+		return makeTestMessage(bindingSuccess, id,
+			testAttribute{
+				typ:   attrXORMappedAddress,
+				value: xorAddressValue(net.ParseIP("198.51.100.1"), 41000, id),
+			},
+			testAttribute{
+				typ:   attrOtherAddress,
+				value: plainAddressValue(alternate.LocalAddr().(*net.UDPAddr).IP, alternate.LocalAddr().(*net.UDPAddr).Port),
+			},
+		), nil
+	})
+	alternateDone := serveOneBinding(alternate, func(id transactionID, clientAddr *net.UDPAddr) ([]byte, error) {
+		alternateSource <- clientAddr
+		return makeTestMessage(bindingSuccess, id, testAttribute{
+			typ:   attrXORMappedAddress,
+			value: xorAddressValue(net.ParseIP("198.51.100.1"), 41001, id),
+		}), nil
+	})
+
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	firstTransaction, err := NewBindingTransaction(primary.LocalAddr().(*net.UDPAddr))
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(testSocketTimeout)))
+	first, err := client.Do(firstTransaction)
+	require.NoError(t, err)
+	require.NotNil(t, first.OtherAddr)
+
+	secondTransaction, err := NewBindingTransaction(first.OtherAddr)
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(testSocketTimeout)))
+	second, err := client.Do(secondTransaction)
+	require.NoError(t, err)
+	require.Equal(t, "198.51.100.1:41001", second.MappedAddr.String())
+
+	firstSource := <-primarySource
+	secondSource := <-alternateSource
+	require.True(t, firstSource.IP.Equal(secondSource.IP))
+	require.Equal(t, firstSource.Port, secondSource.Port)
+	require.Equal(t, conn.LocalAddr().(*net.UDPAddr).Port, firstSource.Port)
+	waitServer(t, primaryDone)
+	waitServer(t, alternateDone)
+}
+
+func TestClientValidatesArguments(t *testing.T) {
+	server := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3478}
+	transaction, err := NewBindingTransaction(server)
+	require.NoError(t, err)
+
+	_, err = NewClient(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-nil UDP connection")
+
+	var nilClient *Client
+	_, err = nilClient.Do(transaction)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil STUN Client")
+
+	_, err = (&Client{}).Do(transaction)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no UDP connection")
+
+	conn := listenUDP4(t)
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	_, err = client.Do(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-nil BindingTransaction")
+
+	var nilTransaction *BindingTransaction
+	_, matched, err := nilTransaction.Process(nil, nil)
+	require.False(t, matched)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil STUN BindingTransaction")
+}
+
+func TestClientPreservesWriteNetError(t *testing.T) {
+	conn := listenUDP4(t)
+	client, err := NewClient(conn)
+	require.NoError(t, err)
+	transaction, err := NewBindingTransaction(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3478})
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	_, err = client.Do(transaction)
+	var netErr net.Error
+	require.True(t, errors.As(err, &netErr))
+}

--- a/net/stun/doc.go
+++ b/net/stun/doc.go
@@ -1,0 +1,41 @@
+// Copyright 2026 fatedier, fatedier@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stun implements minimal STUN message decoding and Binding
+// transactions.
+//
+// Message is the binary codec layer. It owns its bytes, strictly validates
+// framing, and does not expose arbitrary STUN attribute construction.
+// BindingTransaction adds Binding request construction, transaction matching,
+// and expected-source validation. Client is the synchronous network I/O layer
+// over the same transaction core:
+//
+//	client, err := stun.NewClient(conn)
+//	transaction, err := stun.NewBindingTransaction(server)
+//	response, err := client.Do(transaction)
+//
+// Callers that already own a UDP read loop can use the transaction directly:
+//
+//	transaction, err := stun.NewBindingTransaction(server)
+//	request, err := transaction.MarshalBinary()
+//	_, err = conn.WriteToUDP(request, server)
+//	// Read packet and source using the caller's existing demultiplexer.
+//	response, matched, err := transaction.Process(packet, source)
+//
+// Client borrows its UDP connection. The caller remains responsible for its
+// deadlines, lifetime, and serializing reads while Client.Do is running. The
+// package does not create or close sockets, retry requests, start background
+// goroutines, discover NAT behavior, or implement authentication, TURN, or ICE.
+// Binding responses support both IPv4 and IPv6 address attributes.
+package stun

--- a/net/stun/errors.go
+++ b/net/stun/errors.go
@@ -1,0 +1,53 @@
+// Copyright 2026 fatedier, fatedier@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stun
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrMalformedResponse indicates invalid STUN framing or an invalid
+	// supported attribute. BindingTransaction only returns it after a datagram
+	// has been associated with the transaction.
+	ErrMalformedResponse = errors.New("malformed STUN response")
+	// ErrUnsupportedAddressFamily indicates that an address attribute uses an
+	// address family other than IPv4 or IPv6.
+	ErrUnsupportedAddressFamily = errors.New("unsupported STUN address family")
+)
+
+// ResponseError describes an error returned by a STUN Binding server.
+type ResponseError struct {
+	// Code is the numeric STUN error code.
+	Code int
+	// Reason is the server-provided reason phrase.
+	Reason string
+}
+
+// Error implements error.
+func (e *ResponseError) Error() string {
+	if e == nil {
+		return "STUN binding error response"
+	}
+	if e.Reason == "" {
+		return fmt.Sprintf("STUN binding error %d", e.Code)
+	}
+	return fmt.Sprintf("STUN binding error %d: %s", e.Code, e.Reason)
+}
+
+func malformedResponsef(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrMalformedResponse, fmt.Sprintf(format, args...))
+}

--- a/net/stun/fuzz_test.go
+++ b/net/stun/fuzz_test.go
@@ -1,0 +1,59 @@
+package stun
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+func FuzzParseMessageNoPanic(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add(makeTestMessage(bindingSuccess, transactionID{}))
+	f.Add(makeTestMessage(bindingError, transactionID{}, testAttribute{
+		typ:   attrErrorCode,
+		value: []byte{0, 0, 4, 0},
+	}))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var m Message
+		err := m.UnmarshalBinary(data)
+		if err != nil {
+			return
+		}
+		encoded, err := m.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := parseMessage(encoded); err != nil {
+			t.Fatalf("MarshalBinary produced an invalid message: %v", err)
+		}
+		switch m.typ {
+		case bindingSuccess:
+			_, _ = decodeBindingSuccess(m)
+		case bindingError:
+			_ = decodeBindingError(m)
+		}
+	})
+}
+
+func FuzzBindingTransactionProcessNoPanic(f *testing.F) {
+	id := transactionID{1, 2, 3}
+	server := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3478}
+	transaction, err := newBindingTransaction(server, bytes.NewReader(id[:]))
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add([]byte(nil))
+	f.Add(makeTestMessage(bindingSuccess, id))
+	f.Add(makeTestMessage(bindingError, id, testAttribute{
+		typ:   attrErrorCode,
+		value: []byte{0, 0, 4, 0},
+	}))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, matched, err := transaction.Process(data, server)
+		if !matched && err != nil {
+			t.Fatalf("unmatched datagram returned an error: %v", err)
+		}
+	})
+}

--- a/net/stun/message.go
+++ b/net/stun/message.go
@@ -1,0 +1,209 @@
+// Copyright 2026 fatedier, fatedier@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stun
+
+import (
+	"encoding"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const (
+	messageHeaderSize   = 20
+	transactionIDSize   = 12
+	attributeHeaderSize = 4
+	attributeAlignment  = 4
+	magicCookie         = 0x2112a442
+
+	bindingRequest = 0x0001
+	bindingSuccess = 0x0101
+	bindingError   = 0x0111
+
+	attrMappedAddress    = 0x0001
+	attrChangedAddress   = 0x0005
+	attrErrorCode        = 0x0009
+	attrXORMappedAddress = 0x0020
+	attrOtherAddress     = 0x802c
+)
+
+type transactionID [transactionIDSize]byte
+
+type attributeValue struct {
+	typ   uint16
+	value []byte
+}
+
+// Message is an ownership-safe binary codec for one STUN message.
+//
+// The zero value is ready for UnmarshalBinary. A successful unmarshal replaces
+// the previous contents and copies data; a failed unmarshal leaves the Message
+// unchanged. MarshalBinary returns a new byte slice on every call. Message
+// preserves attributes it does not interpret, including their padding, but it
+// deliberately exposes no general-purpose attribute setters.
+//
+// A Message may be reused serially. It must not be unmarshaled concurrently
+// with any other method call.
+type Message struct {
+	typ           uint16
+	transactionID transactionID
+	attributes    []attributeValue
+	wire          []byte
+}
+
+var (
+	_ encoding.BinaryMarshaler   = Message{}
+	_ encoding.BinaryUnmarshaler = (*Message)(nil)
+)
+
+// MarshalBinary returns an independent copy of the encoded message.
+func (m Message) MarshalBinary() ([]byte, error) {
+	if len(m.wire) == 0 {
+		return nil, fmt.Errorf("cannot marshal an uninitialized STUN Message")
+	}
+	return append([]byte(nil), m.wire...), nil
+}
+
+// UnmarshalBinary strictly decodes one complete STUN datagram.
+//
+// The input is copied. Malformed framing wraps ErrMalformedResponse. Supported
+// Binding semantics are interpreted later by BindingTransaction.
+func (m *Message) UnmarshalBinary(data []byte) error {
+	if m == nil {
+		return fmt.Errorf("cannot unmarshal into a nil STUN Message")
+	}
+
+	decoded, err := parseMessageCopy(data)
+	if err != nil {
+		return err
+	}
+	*m = decoded
+	return nil
+}
+
+// TransactionID returns the message's 96-bit transaction identifier.
+func (m Message) TransactionID() [12]byte {
+	return m.transactionID
+}
+
+// IsBindingRequest reports whether m is a STUN Binding request.
+func (m Message) IsBindingRequest() bool {
+	return len(m.wire) != 0 && m.typ == bindingRequest
+}
+
+// IsBindingResponse reports whether m is a success or error response to a
+// STUN Binding request. It does not associate the response with a transaction.
+func (m Message) IsBindingResponse() bool {
+	return len(m.wire) != 0 && (m.typ == bindingSuccess || m.typ == bindingError)
+}
+
+func newTransactionID(r io.Reader) (transactionID, error) {
+	var id transactionID
+	_, err := io.ReadFull(r, id[:])
+	return id, err
+}
+
+func newBindingRequestMessage(id transactionID) Message {
+	request := buildBindingRequest(id)
+	return Message{
+		typ:           bindingRequest,
+		transactionID: id,
+		wire:          append([]byte(nil), request[:]...),
+	}
+}
+
+func buildBindingRequest(id transactionID) [messageHeaderSize]byte {
+	var request [messageHeaderSize]byte
+	binary.BigEndian.PutUint16(request[0:2], bindingRequest)
+	binary.BigEndian.PutUint16(request[2:4], 0)
+	binary.BigEndian.PutUint32(request[4:8], magicCookie)
+	copy(request[8:20], id[:])
+	return request
+}
+
+func isCorrelatedResponse(data []byte, id transactionID) bool {
+	if len(data) < messageHeaderSize {
+		return false
+	}
+	typ := binary.BigEndian.Uint16(data[0:2])
+	if typ != bindingSuccess && typ != bindingError {
+		return false
+	}
+	if binary.BigEndian.Uint32(data[4:8]) != magicCookie {
+		return false
+	}
+	return transactionID(data[8:20]) == id
+}
+
+func parseMessage(data []byte) (Message, error) {
+	return parseMessageCopy(data)
+}
+
+func parseMessageCopy(data []byte) (Message, error) {
+	var m Message
+	if len(data) < messageHeaderSize {
+		return m, malformedResponsef("packet is %d bytes, want at least %d", len(data), messageHeaderSize)
+	}
+
+	wire := append([]byte(nil), data...)
+	m.typ = binary.BigEndian.Uint16(wire[0:2])
+	if m.typ&0xc000 != 0 {
+		return Message{}, malformedResponsef("message type 0x%04x has nonzero leading bits", m.typ)
+	}
+	if binary.BigEndian.Uint32(wire[4:8]) != magicCookie {
+		return Message{}, malformedResponsef("invalid magic cookie")
+	}
+	copy(m.transactionID[:], wire[8:20])
+
+	declaredLength := int(binary.BigEndian.Uint16(wire[2:4]))
+	if declaredLength%attributeAlignment != 0 {
+		return Message{}, malformedResponsef("message length %d is not a multiple of %d", declaredLength, attributeAlignment)
+	}
+	expectedLength := messageHeaderSize + declaredLength
+	if len(wire) != expectedLength {
+		return Message{}, malformedResponsef("packet is %d bytes, header declares %d", len(wire), expectedLength)
+	}
+
+	for offset := messageHeaderSize; offset < len(wire); {
+		remaining := len(wire) - offset
+		if remaining < attributeHeaderSize {
+			return Message{}, malformedResponsef("attribute header is truncated at offset %d", offset)
+		}
+		attributeType := binary.BigEndian.Uint16(wire[offset : offset+2])
+		valueLength := int(binary.BigEndian.Uint16(wire[offset+2 : offset+4]))
+		paddedLength := (valueLength + attributeAlignment - 1) &^ (attributeAlignment - 1)
+		if remaining-attributeHeaderSize < paddedLength {
+			return Message{}, malformedResponsef("attribute 0x%04x value or padding is truncated", attributeType)
+		}
+		valueStart := offset + attributeHeaderSize
+		m.attributes = append(m.attributes, attributeValue{
+			typ:   attributeType,
+			value: wire[valueStart : valueStart+valueLength],
+		})
+
+		offset = valueStart + paddedLength
+	}
+	m.wire = wire
+	return m, nil
+}
+
+func (m Message) firstAttribute(typ uint16) ([]byte, bool) {
+	for _, attribute := range m.attributes {
+		if attribute.typ == typ {
+			return attribute.value, true
+		}
+	}
+	return nil, false
+}

--- a/net/stun/message_test.go
+++ b/net/stun/message_test.go
@@ -1,0 +1,256 @@
+package stun
+
+import (
+	"encoding"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testAttribute struct {
+	typ     uint16
+	value   []byte
+	padding []byte
+}
+
+func makeTestMessage(typ uint16, id transactionID, attributes ...testAttribute) []byte {
+	length := 0
+	for _, attribute := range attributes {
+		length += attributeHeaderSize + (len(attribute.value)+attributeAlignment-1)&^(attributeAlignment-1)
+	}
+	packet := make([]byte, messageHeaderSize, messageHeaderSize+length)
+	binary.BigEndian.PutUint16(packet[0:2], typ)
+	binary.BigEndian.PutUint16(packet[2:4], uint16(length))
+	binary.BigEndian.PutUint32(packet[4:8], magicCookie)
+	copy(packet[8:20], id[:])
+
+	for _, attribute := range attributes {
+		start := len(packet)
+		paddedLength := (len(attribute.value) + attributeAlignment - 1) &^ (attributeAlignment - 1)
+		packet = append(packet, make([]byte, attributeHeaderSize+paddedLength)...)
+		binary.BigEndian.PutUint16(packet[start:start+2], attribute.typ)
+		binary.BigEndian.PutUint16(packet[start+2:start+4], uint16(len(attribute.value)))
+		copy(packet[start+4:], attribute.value)
+		copy(packet[start+4+len(attribute.value):], attribute.padding)
+	}
+	return packet
+}
+
+func decodeHex(t *testing.T, value string) []byte {
+	t.Helper()
+	data, err := hex.DecodeString(strings.ReplaceAll(value, " ", ""))
+	require.NoError(t, err)
+	return data
+}
+
+func TestBuildBindingRequestGolden(t *testing.T) {
+	id := transactionID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b}
+	request := buildBindingRequest(id)
+	require.Equal(t,
+		"000100002112a442000102030405060708090a0b",
+		hex.EncodeToString(request[:]),
+	)
+}
+
+func TestMessageBinaryCodecOwnershipAndRoundTrip(t *testing.T) {
+	id := transactionID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	want := makeTestMessage(bindingSuccess, id,
+		testAttribute{typ: 0x7777, value: []byte{1}, padding: []byte{0xaa, 0xbb, 0xcc}},
+		testAttribute{typ: attrMappedAddress, value: plainAddressValue(net.ParseIP("192.0.2.10"), 3478)},
+	)
+	input := append([]byte(nil), want...)
+
+	var message Message
+	var unmarshaler encoding.BinaryUnmarshaler = &message
+	require.NoError(t, unmarshaler.UnmarshalBinary(input))
+	require.True(t, message.IsBindingResponse())
+	require.False(t, message.IsBindingRequest())
+	require.Equal(t, [12]byte(id), message.TransactionID())
+
+	for i := range input {
+		input[i] ^= 0xff
+	}
+	var marshaler encoding.BinaryMarshaler = message
+	first, err := marshaler.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, want, first)
+
+	first[0] ^= 0xff
+	second, err := message.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, want, second)
+}
+
+func TestMessageReuseAndFailedUnmarshal(t *testing.T) {
+	firstID := transactionID{1, 2, 3}
+	secondID := transactionID{4, 5, 6}
+	first := makeTestMessage(bindingSuccess, firstID)
+	second := buildBindingRequest(secondID)
+
+	var message Message
+	require.NoError(t, message.UnmarshalBinary(first))
+	require.True(t, message.IsBindingResponse())
+	require.NoError(t, message.UnmarshalBinary(second[:]))
+	require.True(t, message.IsBindingRequest())
+	require.Equal(t, [12]byte(secondID), message.TransactionID())
+
+	before, err := message.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, second[:], before)
+	malformed := append(append([]byte(nil), second[:]...), 0, 0, 0, 0)
+	require.ErrorIs(t, message.UnmarshalBinary(malformed), ErrMalformedResponse)
+	after, err := message.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+
+	var zero Message
+	_, err = zero.MarshalBinary()
+	require.Error(t, err)
+	var nilMessage *Message
+	require.Error(t, nilMessage.UnmarshalBinary(first))
+}
+
+func TestParseRFC5769BindingResponses(t *testing.T) {
+	tests := []struct {
+		name       string
+		packet     string
+		expectedIP string
+	}{
+		{
+			name: "IPv4",
+			packet: "0101003c2112a442b7e7a701bc34d686fa87dfae" +
+				"8022000b7465737420766563746f7220" +
+				"002000080001a147e112a643" +
+				"000800142b91f599fd9e90c38c7489f92af9ba53f06be7d7" +
+				"80280004c07d4c96",
+			expectedIP: "192.0.2.1",
+		},
+		{
+			name: "IPv6",
+			packet: "010100482112a442b7e7a701bc34d686fa87dfae" +
+				"8022000b7465737420766563746f7220" +
+				"002000140002a1470113a9faa5d3f179bc25f4b5bed2b9d9" +
+				"00080014a382954e4be67bf11784c97c8292c275bfe3ed41" +
+				"80280004c8fb0b4c",
+			expectedIP: "2001:db8:1234:5678:11:2233:4455:6677",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := decodeHex(t, tt.packet)
+			m, err := parseMessage(packet)
+			require.NoError(t, err)
+			response, err := decodeBindingSuccess(m)
+			require.NoError(t, err)
+			require.NotNil(t, response.MappedAddr)
+			require.True(t, response.MappedAddr.IP.Equal(net.ParseIP(tt.expectedIP)))
+			require.Equal(t, 32853, response.MappedAddr.Port)
+			require.Nil(t, response.OtherAddr)
+		})
+	}
+}
+
+func TestParseMessageIntentionallySkipsUnknownAttributesInBothRanges(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	// This minimal client intentionally skips unknown comprehension-required and
+	// comprehension-optional attributes to preserve its explicit compatibility contract.
+	packet := makeTestMessage(bindingSuccess, id,
+		testAttribute{typ: 0x7777, value: []byte{0xaa}, padding: []byte{0xde, 0xad, 0xbe}},
+		testAttribute{typ: 0x8777, value: []byte{0xbb}},
+		testAttribute{typ: attrMappedAddress, value: plainAddressValue(net.ParseIP("192.0.2.9"), 3478)},
+	)
+	m, err := parseMessage(packet)
+	require.NoError(t, err)
+	response, err := decodeBindingSuccess(m)
+	require.NoError(t, err)
+	require.Equal(t, "192.0.2.9:3478", response.MappedAddr.String())
+}
+
+func TestParseMessageRejectsMalformedFraming(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	valid := makeTestMessage(bindingSuccess, id)
+
+	tests := []struct {
+		name   string
+		packet []byte
+	}{
+		{name: "empty", packet: nil},
+		{name: "short header", packet: valid[:messageHeaderSize-1]},
+		{name: "leading type bits", packet: func() []byte {
+			packet := append([]byte(nil), valid...)
+			packet[0] |= 0xc0
+			return packet
+		}()},
+		{name: "bad cookie", packet: func() []byte {
+			packet := append([]byte(nil), valid...)
+			packet[4] ^= 0xff
+			return packet
+		}()},
+		{name: "non-aligned declared length", packet: func() []byte {
+			packet := append(append([]byte(nil), valid...), 0, 0)
+			binary.BigEndian.PutUint16(packet[2:4], 2)
+			return packet
+		}()},
+		{name: "truncated datagram", packet: func() []byte {
+			packet := append([]byte(nil), valid...)
+			binary.BigEndian.PutUint16(packet[2:4], 4)
+			return packet
+		}()},
+		{name: "trailing bytes", packet: append(append([]byte(nil), valid...), 0, 0, 0, 0)},
+		{name: "truncated attribute value", packet: func() []byte {
+			packet := makeTestMessage(bindingSuccess, id, testAttribute{typ: 0x7777})
+			binary.BigEndian.PutUint16(packet[22:24], 4)
+			return packet
+		}()},
+		{name: "truncated attribute padding", packet: func() []byte {
+			packet := makeTestMessage(bindingSuccess, id, testAttribute{typ: 0x7777, value: []byte{1}})
+			return packet[:len(packet)-1]
+		}()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseMessage(tt.packet)
+			require.ErrorIs(t, err, ErrMalformedResponse)
+		})
+	}
+}
+
+func TestIsCorrelatedResponse(t *testing.T) {
+	id := transactionID{1, 2, 3}
+	valid := makeTestMessage(bindingSuccess, id)
+	require.True(t, isCorrelatedResponse(valid, id))
+	require.False(t, isCorrelatedResponse(valid[:19], id))
+
+	wrongType := append([]byte(nil), valid...)
+	binary.BigEndian.PutUint16(wrongType[0:2], bindingRequest)
+	require.False(t, isCorrelatedResponse(wrongType, id))
+
+	wrongCookie := append([]byte(nil), valid...)
+	wrongCookie[4] ^= 1
+	require.False(t, isCorrelatedResponse(wrongCookie, id))
+
+	wrongID := append([]byte(nil), valid...)
+	wrongID[8] ^= 1
+	require.False(t, isCorrelatedResponse(wrongID, id))
+}
+
+func TestNewTransactionIDEntropyError(t *testing.T) {
+	wantErr := errors.New("entropy failed")
+	_, err := newTransactionID(errorReader{err: wantErr})
+	require.ErrorIs(t, err, wantErr)
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}


### PR DESCRIPTION
## Summary

This PR adds a stdlib-only `net/stun` package for the minimal STUN client needed by [fatedier/frp#5298](https://github.com/fatedier/frp/issues/5298). It keeps protocol parsing independent from transport policy and introduces both synchronous and caller-managed I/O modes.

## Implementation

- Adds an ownership-safe `Message` codec with strict framing and independent buffers.
- Adds immutable `BindingTransaction` values with `MarshalBinary`, `Process`, and transaction ID access.
- Adds `Client.Do` for synchronous UDP I/O while borrowing the caller-owned socket.
- Shares request encoding, correlation, matching, and response error handling between both API layers.

## Protocol and I/O semantics

- Supports legacy and modern mapped/alternate address attributes across IPv4 and IPv6.
- Enforces source, message type, magic cookie, transaction ID, strict framing, and IPv6 zone matching.
- Classifies unrelated datagrams, correlated malformed responses, STUN error responses, and network errors distinctly.
- `Client.Do` does not close or replace the socket, modify deadlines, retry, or start background goroutines.

## Validation

- `go test ./...`
- `go test -race ./net/stun`
- `go vet ./...`
- `staticcheck ./net/stun` and `golangci-lint run ./...`
- Repeated `net/stun` tests, two bounded fuzz targets, and focused race runs
- Android arm64 CGO-disabled and Linux 386 final-link validation

The standard parallel `go test -race -count=1 ./...` command remains affected only by the pre-existing `pool/buf_test.go:66` test assumption that a `sync.Pool` item is retained after `Put`; the focused and serialized full-repository race runs pass.

This package has no external dependencies.